### PR TITLE
Add progress iterator when read_group to allow to skip grouping on big recordsets e.g. in graph or pivot 

### DIFF
--- a/web_progress/README.rst
+++ b/web_progress/README.rst
@@ -15,6 +15,7 @@ Progress bar for Odoo waiting screen, possibility to cancel an ongoing operation
 **web_progress** exists for Odoo 11.0 and 12.0 (CE and EE).
 
 Author: Grzegorz Marczyński
+Contributor: Guenter Selbert
 
 License: LGPL-3.
 
@@ -77,6 +78,11 @@ Progress tracking may be added to sub-operations as well:
 
 Release Notes
 -------------
+
+1.3 - 2019-08-08 - features:
+
+- add progress iterator to read_group to allow to skip grouping on time cost result sets in graph or pivot views
+- changed the default color of progressbar to odoo's ci secondary color
 
 1.2 - 2019-06-24 - fixes:
 

--- a/web_progress/__manifest__.py
+++ b/web_progress/__manifest__.py
@@ -13,7 +13,7 @@
     'author': "Grzegorz Marczyński, Guenter Selbert (Contributor)",
     'category': 'UI',
 
-    'version': '11.0.1.2',
+    'version': '11.0.1.3',
 
     'depends': ['web',
                 'bus',

--- a/web_progress/__manifest__.py
+++ b/web_progress/__manifest__.py
@@ -10,7 +10,7 @@
     # Try to import some CSV file to any model to see it in action.
     # """,
 
-    'author': "Grzegorz Marczyński",
+    'author': "Grzegorz Marczyński, Guenter Selbert (Contributor)",
     'category': 'UI',
 
     'version': '11.0.1.2',

--- a/web_progress/models/base.py
+++ b/web_progress/models/base.py
@@ -164,3 +164,8 @@ class Base(models.AbstractModel):
                 ret += super(Base, sub)._export_rows(fields, batch_invalidate=False)
             return ret
         return super(Base, self)._export_rows(fields, batch_invalidate=batch_invalidate)
+
+    @api.model
+    def read_group(self, domain, fields, groupby, offset=0, limit=None, orderby=False, lazy=True):
+        read_group_progress = super(Base, self.with_context(progress_iter=True)).read_group
+        return read_group_progress(domain, fields, groupby, offset=offset, limit=limit, orderby=orderby, lazy=lazy)

--- a/web_progress/static/src/css/views.css
+++ b/web_progress/static/src/css/views.css
@@ -14,7 +14,7 @@
 #progress_bar {
     width: 1%;
     height: 10px;
-    background-color: #00EE00;
+    background-color: #00a09d;
     border-radius: 5px;
 }
 


### PR DESCRIPTION
Nice module! I also changed the default color of the progressbar to odoo's corporate secondary color.