### PR TITLE
[IMP] add progressbar when grouping and searching in views

### DIFF
--- a/web_progress/README.rst
+++ b/web_progress/README.rst
@@ -15,6 +15,7 @@ Progress bar for Odoo waiting screen, possibility to cancel an ongoing operation
 **web_progress** exists for Odoo 11.0 and 12.0 (CE and EE).
 
 Author: Grzegorz Marczyński
+Contributor: Guenter Selbert (Contributor)
 
 License: LGPL-3.
 
@@ -86,6 +87,12 @@ Progress tracking may be added to sub-operations as well:
 
 Release Notes
 -------------
+
+1.4 - 2019-08-09 - new functionality
+
+- add progress iterator to read_group to allow to skip grouping on time cost results e.g. in graph or pivot views
+- add progress iterator to search_read to allow to skip searching on time cost results in search bar
+
 
 1.3 - 2019-07-15 - new functionality
 

--- a/web_progress/__manifest__.py
+++ b/web_progress/__manifest__.py
@@ -10,10 +10,10 @@
     # Try to import some CSV file to any model to see it in action.
     # """,
 
-    'author': "Grzegorz Marczyński",
+    'author': "Grzegorz Marczyński, Guenter Selbert (Contributor)",
     'category': 'Productivity',
 
-    'version': '11.0.1.3',
+    'version': '11.0.1.4',
 
     'depends': ['web',
                 'bus',

--- a/web_progress/models/base.py
+++ b/web_progress/models/base.py
@@ -164,3 +164,19 @@ class Base(models.AbstractModel):
                 ret += super(Base, sub)._export_rows(fields, batch_invalidate=False)
             return ret
         return super(Base, self)._export_rows(fields, batch_invalidate=batch_invalidate)
+
+    @api.model
+    def read_group(self, domain, fields, groupby, offset=0, limit=None, orderby=False, lazy=True):
+        """
+        Add progress when grouping results e.g. in graph or pivot view
+        """
+        read_group_progress = super(Base, self.with_context(progress_iter=True)).read_group
+        return read_group_progress(domain, fields, groupby, offset=offset, limit=limit, orderby=orderby, lazy=lazy)
+
+    @api.model
+    def search_read(self, domain=None, fields=None, offset=0, limit=None, order=None):
+        """
+        Add progress when searching for records e.g. in list or kanban view
+        """
+        search_read_progress = super(Base, self.with_context(progress_iter=True)).search_read
+        return search_read_progress(domain=domain, fields=fields, offset=offset, limit=limit, order=order)


### PR DESCRIPTION
Add progress iterator when methods read_group and search_read are called to allow skipping long running search queries