### PR TITLE
[FIX] web controller context being lost

### DIFF
--- a/web_progress/controllers/main.py
+++ b/web_progress/controllers/main.py
@@ -2,10 +2,11 @@ import json
 from odoo import http
 from odoo.addons.web.controllers.main import ReportController, request
 
+
 class WPReportController(ReportController):
 
     @http.route(['/report/download'], type='http', auth="user")
-    def report_download(self, data, token):
+    def report_download(self, data, token, context=None):
         """
         Pass web progress code from request content to the context
         """
@@ -17,8 +18,9 @@ class WPReportController(ReportController):
                 context.update(request_context)
                 request._env = request.env(context=context)
                 request._context = context
+                context = json.dumps(context)
         web_progress_obj = request.env['web.progress']
         web_progress_obj.web_progress_percent(0, 'Report')
-        ret = super(WPReportController, self).report_download(data, token)
+        ret = super(WPReportController, self).report_download(data, token, context=context)
         web_progress_obj.web_progress_percent(100, 'Report done')
         return ret

--- a/web_progress/static/src/js/ajax.js
+++ b/web_progress/static/src/js/ajax.js
@@ -111,7 +111,7 @@ function get_file(options) {
     var complete = options.complete;
     if (options.data && options.data.data) {
         var data = JSON.parse(options.data.data);
-        var context = data.context;
+        var context = options.data.context && JSON.parse(options.data.context);
         if (!context && Array.isArray(data)) {
             data.push({});
             context = data[data.length - 1];


### PR DESCRIPTION
When the web-ui passes a specific user context, it should be passed to the report.